### PR TITLE
Improve Windows Compatibility

### DIFF
--- a/rust/reason-othello/Cargo.toml
+++ b/rust/reason-othello/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Aidan Swope <aidanswope@gmail.com>"]
 edition = "2018"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 
 [dependencies]
 packed_simd = { version = "0.3.4", package = "packed_simd_2" }

--- a/rust/reason-othello/Cargo.toml
+++ b/rust/reason-othello/Cargo.toml
@@ -12,6 +12,8 @@ packed_simd = { version = "0.3.4", package = "packed_simd_2" }
 
 [dev-dependencies]
 criterion = { version = "0.3.4", features = ["html_reports"] }
+
+[target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.4.2", features = ["flamegraph", "criterion"]}
 
 [[bench]]

--- a/rust/reason-othello/benches/perft.rs
+++ b/rust/reason-othello/benches/perft.rs
@@ -1,4 +1,6 @@
 use criterion::*;
+
+#[cfg(unix)]
 use pprof::criterion::{Output, PProfProfiler};
 
 use reason_othello::test_utils::perft;
@@ -16,9 +18,18 @@ fn criterion_perft(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(unix)]
 criterion_group! {
     name = perft;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_perft
 }
+
+#[cfg(not(unix))]
+criterion_group! {
+    name = perft;
+    config = Criterion::default();
+    targets = criterion_perft
+}
+
 criterion_main!(perft);


### PR DESCRIPTION
The crate currently fails to `test` or `bench` on Windows due to the `pprof` crate. This PR just changes `pprof` to be used only on Unix systems.